### PR TITLE
Cookie improvement

### DIFF
--- a/design/src/system/assets/scripts/notification-bar.js
+++ b/design/src/system/assets/scripts/notification-bar.js
@@ -10,7 +10,7 @@
     },
     close: function(barId, cookie) {
       $('#' + barId).slideUp();
-      $.cookie(cookie, true, { path: '/' });
+      $.cookie(cookie, true, { path: '/', expires: 365 });
     },
     reset: function(cookie) {
       $.removeCookie(cookie, { path: '/' });

--- a/design/src/templates/pages/features/cookie-bar.hbs
+++ b/design/src/templates/pages/features/cookie-bar.hbs
@@ -17,7 +17,7 @@ section: Features
 			<h1>Cookie Bar</h1>
 			<div class="content">
 				
-				Cookie bar displays on first page of first visit and then a 'seen-cookie-notice' cookie is set, ensuring it is not shown again.
+				Cookie bar displays on first page of first visit and then a 'seen-cookie-notice' cookie is set, ensuring it is not shown again for a period of 365 days.
 
 				<a id='reset-cookiebar' href='#' class='btn btn-primary'>Reset Cookiebar</a><br/>
 				** Cookie bar will then persist for one page view*


### PR DESCRIPTION
Fixed https://github.com/sdl/dxa-html-design/issues/2
This PR sets the cookie-notice cookie lifetime to a year instead of the session.
