### PR TITLE
Update Node version instructions in design/README

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -8,7 +8,7 @@ The HTML Design comes with a Grunt `Gruntfile.js` which defines the build tasks.
 ## First time setup
 1. Install GIT (this is required by Bower)
 
-2. Install [Node.js](http://nodejs.org/)
+2. Install [Node.js](http://nodejs.org/) version 4. (i.e. v4.4.5 LTS, [Node v6 will not work](https://github.com/sdl/dxa-html-design/issues/8) )
 
 3. Install [Grunt](http://gruntjs.com/) and [Bower](http://bower.io/) globally from the command prompt:
 


### PR DESCRIPTION
The HTML design will not build with the latest Node JS version, version 6. See https://github.com/sdl/dxa-html-design/issues/8 
Updating the design README to instruct which version to install.
